### PR TITLE
Reorganize portfolio chart display by security

### DIFF
--- a/charts.js
+++ b/charts.js
@@ -820,45 +820,5 @@ async function fetchCoinNameHistoricalData(coinName) {
         return [];
     }
 }
-// チャート
-// 表示モードを切り替える（デスクトップ/モバイル統合版）
-function toggleChartMode() {
-    // 現在のモードを取得（引数なしで自動判定）
-    const currentMode = window.portfolioChartMode || safeGetJSON('portfolioChartMode', 'combined');
-    const newMode = (currentMode === 'combined') ? 'individual' : 'combined';
-
-    // ChartElementIdsを使用してDOM要素を取得
-    const toggleButton = document.getElementById(ChartElementIds.getToggleButton());
-    const chartTitle = document.getElementById(ChartElementIds.getTitle());
-
-    window.portfolioChartMode = newMode;
-    safeSetJSON('portfolioChartMode', newMode);
-
-    // モバイルかデスクトップかを判定
-    const isMobileView = typeof isMobile === 'function' && isMobile();
-
-    if (newMode === 'combined') {
-        toggleButton.textContent = isMobileView ? '個別' : '個別表示';
-        toggleButton.title = '各銘柄を個別に表示';
-        chartTitle.textContent = '📈 ポートフォリオ総合損益推移（過去1か月）';
-    } else {
-        toggleButton.textContent = isMobileView ? '合計' : '合計表示';
-        toggleButton.title = 'ポートフォリオ全体の合計を表示';
-        chartTitle.textContent = '📈 各銘柄の個別損益推移（過去1か月）';
-    }
-
-    // チャートを再描画
-    // storage-utils.jsのCacheServiceを使用してポートフォリオデータを取得
-    const portfolioData = window.cache.getPortfolioData();
-    if (portfolioData) {
-        renderAllCoinNamesProfitChart(portfolioData, newMode);
-    } else {
-        console.error('Portfolio data not available for chart rendering');
-        showErrorMessage('チャート表示エラー: ポートフォリオデータが利用できません');
-    }
-
-}
-
 // 関数を即座にグローバルに登録
-window.toggleChartMode = toggleChartMode;
 window.renderAllCoinNamesProfitChart = renderAllCoinNamesProfitChart;

--- a/main.js
+++ b/main.js
@@ -574,6 +574,50 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 30000);
 });
 
+// ===================================================================
+// INDIVIDUAL COIN PROFIT CHART RENDERING
+// ===================================================================
+
+/**
+ * 個別銘柄の損益推移チャートを描画
+ * @param {string} coinName - 銘柄シンボル（例: "BTC"）
+ */
+async function renderCoinProfitChart(coinName) {
+    try {
+        // ポートフォリオデータを取得
+        const portfolioData = window.cache.getPortfolioData();
+        if (!portfolioData || !portfolioData.coins || !portfolioData.coins[coinName]) {
+            throw new Error(`${coinName}のデータが見つかりません`);
+        }
+
+        const coinData = portfolioData.coins[coinName];
+        const canvasId = `${coinName.toLowerCase()}-profit-chart`;
+
+        // 価格履歴を取得
+        showInfoMessage(`${coinName}の価格履歴を取得中...`);
+        const priceHistory = await fetchCoinNamePriceHistory(coinName);
+
+        // 損益推移データを生成
+        const profitData = generateHistoricalProfitTimeSeries(
+            coinData.allTransactions,
+            priceHistory
+        );
+
+        // チャートを描画
+        displayProfitChart(
+            canvasId,
+            profitData,
+            `${coinName} 損益推移（過去1か月）`
+        );
+
+        showSuccessMessage(`${coinName}の損益チャートを表示しました`);
+
+    } catch (error) {
+        console.error(`${coinName}チャート描画エラー:`, error);
+        showErrorMessage(`${coinName}チャート描画失敗: ${error.message}`);
+    }
+}
+
 // グローバル関数として明示的に定義（HTMLから呼び出し可能にする）
 (function () {
     // 関数が定義されているか確認してからグローバルに設定
@@ -584,6 +628,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (typeof clearPriceData === 'function') window.clearPriceData = clearPriceData;
     if (typeof showPriceDataStatus === 'function') window.showPriceDataStatus = showPriceDataStatus;
     if (typeof updatePriceDataStatusDisplay === 'function') window.updatePriceDataStatusDisplay = updatePriceDataStatusDisplay;
+    if (typeof renderCoinProfitChart === 'function') window.renderCoinProfitChart = renderCoinProfitChart;
     // トースト通知関数をグローバルに公開（他のJSファイルから呼び出し可能に）
     if (typeof showSuccessMessage === 'function') window.showSuccessMessage = showSuccessMessage;
     if (typeof showErrorMessage === 'function') window.showErrorMessage = showErrorMessage;

--- a/portfolio.js
+++ b/portfolio.js
@@ -416,12 +416,9 @@ function displayDashboard(portfolioData) {
             chartContainer.innerHTML = `
                 <div class="table-card" style="background: white; border: 1px solid #cbd5e1; margin-bottom: 15px;">
                     <div class="card-header">
-                        <span id="mobile-chart-title">📈 ポートフォリオ総合損益推移（過去1か月）</span>
-                        <div style="float: right; display: flex; gap: 4px;">
-                            <button id="mobile-chart-mode-toggle" onclick="toggleChartMode()" style="padding: 4px 8px; background: #10b981; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 12px;" title="個別表示に切り替え">
-                                個別
-                            </button>
-                            <button onclick="renderAllCoinNamesProfitChart(window.cache.getPortfolioData(), window.portfolioChartMode || 'combined')" style="padding: 4px 8px; background: #3b82f6; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 12px;">
+                        <span>📈 ポートフォリオ総合損益推移（過去1か月）</span>
+                        <div style="float: right;">
+                            <button onclick="renderAllCoinNamesProfitChart(window.cache.getPortfolioData(), 'combined')" style="padding: 4px 8px; background: #3b82f6; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 12px;">
                                 更新
                             </button>
                         </div>
@@ -436,12 +433,9 @@ function displayDashboard(portfolioData) {
             chartContainer.innerHTML = `
                 <div style="margin-bottom: 25px; background: white; border: 1px solid #cbd5e1; border-radius: 12px; padding: 20px; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);">
                     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
-                        <h3 style="margin: 0; font-size: 18px; font-weight: 600; color: #1e293b;" id="chart-title">📈 ポートフォリオ総合損益推移（過去1か月）</h3>
-                        <div style="display: flex; gap: 8px;">
-                            <button id="chart-mode-toggle" onclick="toggleChartMode()" style="padding: 8px 16px; background: #10b981; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 14px; font-weight: 500;" title="各銘柄を個別に表示">
-                                個別表示
-                            </button>
-                            <button onclick="renderAllCoinNamesProfitChart(window.cache.getPortfolioData(), window.portfolioChartMode || 'combined')" style="padding: 8px 16px; background: #3b82f6; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 14px; font-weight: 500;">
+                        <h3 style="margin: 0; font-size: 18px; font-weight: 600; color: #1e293b;">📈 ポートフォリオ総合損益推移（過去1か月）</h3>
+                        <div>
+                            <button onclick="renderAllCoinNamesProfitChart(window.cache.getPortfolioData(), 'combined')" style="padding: 8px 16px; background: #3b82f6; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 14px; font-weight: 500;">
                                 チャート更新
                             </button>
                         </div>
@@ -520,32 +514,8 @@ function displayDashboard(portfolioData) {
 
     // 全銘柄の損益推移チャートを描画（DOM準備完了後）
     setTimeout(() => {
-        // 保存されたチャートモードを読み込む（デフォルトは'combined'）
-        const savedMode = safeGetJSON('portfolioChartMode', 'combined');
-        window.portfolioChartMode = savedMode;
-
-        // チャートを描画（デスクトップ・モバイル両対応）
-        renderAllCoinNamesProfitChart(portfolioData, savedMode);
-
-        // ボタンのテキストを現在のモードに合わせて設定
-        const toggleButton = document.getElementById(
-            typeof isMobile === 'function' && isMobile() ? 'mobile-chart-mode-toggle' : 'chart-mode-toggle'
-        );
-        const chartTitle = document.getElementById(
-            typeof isMobile === 'function' && isMobile() ? 'mobile-chart-title' : 'chart-title'
-        );
-
-        if (toggleButton && chartTitle) {
-            if (savedMode === 'combined') {
-                toggleButton.textContent = isMobile() ? '個別' : '個別表示';
-                toggleButton.title = '各銘柄を個別に表示';
-                chartTitle.textContent = '📈 ポートフォリオ総合損益推移（過去1か月）';
-            } else {
-                toggleButton.textContent = isMobile() ? '合計' : '合計表示';
-                toggleButton.title = 'ポートフォリオ全体の合計を表示';
-                chartTitle.textContent = '📈 各銘柄の個別損益推移（過去1か月）';
-            }
-        }
+        // サマリータブは常に全体表示（combined）モードで描画
+        renderAllCoinNamesProfitChart(portfolioData, 'combined');
     }, 800); // DOM要素の準備を待つため少し短縮
 }
 

--- a/services/chart-service.js
+++ b/services/chart-service.js
@@ -761,16 +761,9 @@ class ChartService {
 
 /**
  * チャート関連のDOM要素IDを管理するクラス
+ * (注: toggleButtonとtitleは削除されたため、getCanvas()のみ使用)
  */
 class ChartElementIds {
-    static getToggleButton() {
-        return typeof isMobile === 'function' && isMobile() ? 'mobile-chart-mode-toggle' : 'chart-mode-toggle';
-    }
-
-    static getTitle() {
-        return typeof isMobile === 'function' && isMobile() ? 'mobile-chart-title' : 'chart-title';
-    }
-
     static getCanvas() {
         return typeof isMobile === 'function' && isMobile() ? 'mobile-all-coinNames-profit-chart' : 'all-coinNames-profit-chart';
     }

--- a/services/ui-service.js
+++ b/services/ui-service.js
@@ -158,6 +158,15 @@ class TabManager {
         if (targetContent) {
             targetContent.classList.add('active');
         }
+
+        // 個別銘柄タブの場合、チャートを自動描画
+        if (subtabName !== 'summary' && typeof window.renderCoinProfitChart === 'function') {
+            const coinName = subtabName.toUpperCase();
+            // DOM準備後にチャートを描画
+            setTimeout(() => {
+                window.renderCoinProfitChart(coinName);
+            }, 100);
+        }
     }
 
     /**
@@ -332,6 +341,19 @@ class TableRenderer {
         const profitIcon = coinSummary.realizedProfit > 0 ? '📈' : coinSummary.realizedProfit < 0 ? '📉' : '➖';
 
         let html = `
+            <!-- 銘柄チャート -->
+            <div style="background: white; border: 1px solid #cbd5e1; border-radius: 12px; padding: 20px; margin-bottom: 25px; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
+                    <h3 style="margin: 0; font-size: 18px; font-weight: 600; color: #1e293b;">📈 ${coinSummary.coinName} 損益推移（過去1か月）</h3>
+                    <button onclick="renderCoinProfitChart('${coinSummary.coinName}')" style="padding: 8px 16px; background: #3b82f6; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 14px; font-weight: 500;">
+                        チャート更新
+                    </button>
+                </div>
+                <div style="height: 350px; position: relative;">
+                    <canvas id="${coinSummary.coinName.toLowerCase()}-profit-chart" style="max-height: 350px;"></canvas>
+                </div>
+            </div>
+
             <!-- 銘柄サマリーカード -->
             <div style="background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%); border: 1px solid #cbd5e1; border-radius: 12px; padding: 20px; margin-bottom: 25px; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);">
                 <div style="text-align: center; margin-bottom: 15px;">


### PR DESCRIPTION
- サマリータブ: 全体表示のみ（モード切り替えボタンを削除）
- 各銘柄タブ: 個別銘柄の損益推移チャートを表示
- 不要なtoggleChartMode関数を削除
- サブタブ切り替え時に自動的に個別チャートを描画

Changes:
- portfolio.js: サマリータブのチャート表示を簡素化
- services/ui-service.js: 銘柄詳細ページにチャートを追加、自動描画機能を実装
- main.js: renderCoinProfitChart関数を追加
- charts.js: toggleChartMode関数を削除
- services/chart-service.js: ChartElementIdsクラスを簡素化