### PR TITLE
デザイン改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,15 +92,15 @@
                 <!-- タブコンテンツエリア（データがある時に表示） -->
                 <div class="tab-container" id="tabContainer" style="display: none;">
                     <div class="tab-nav">
-                        <button class="tab-button active" onclick="switchTab('portfolio')">ポートフォリオ</button>
-                        <button class="tab-button" onclick="switchTab('trading')">取引履歴</button>
+                        <button class="tab-button active" onclick="switchTab('portfolio')" title="Ctrl+1">ポートフォリオ</button>
+                        <button class="tab-button" onclick="switchTab('trading')" title="Ctrl+2">取引履歴</button>
                     </div>
 
                     <!-- ポートフォリオタブ -->
                     <div class="tab-content active" id="tab-portfolio">
                         <!-- サブタブナビゲーション -->
                         <div class="subtab-nav" id="subtab-nav">
-                            <button class="subtab-button active" onclick="switchSubtab('summary')" id="subtab-summary">サマリー</button>
+                            <button class="subtab-button active" onclick="switchSubtab('summary')" id="subtab-summary" title="Ctrl+S (サマリー) | Ctrl+← (前へ) | Ctrl+→ (次へ)">サマリー</button>
                             <!-- 銘柄別サブタブはJSで動的生成 -->
                         </div>
 
@@ -118,17 +118,6 @@
                                 </div>
                                 <div id="price-update-status" style="font-size: 0.85rem; color: #6c757d;">
                                     価格データなし
-                                </div>
-                            </div>
-
-                            <!-- キーボードショートカット説明 -->
-                            <div class="keyboard-shortcuts" style="margin-bottom: 20px; padding: 10px; background: #fff3cd; border: 1px solid #ffeaa7; border-radius: 8px;">
-                                <div style="font-size: 0.9rem; color: #856404; margin-bottom: 8px;">
-                                    <strong>キーボードショートカット</strong>
-                                </div>
-                                <div style="font-size: 0.8rem; color: #6c757d; line-height: 1.4;">
-                                    <strong>タブ切り替え:</strong> Ctrl+1 (ポートフォリオ) / Ctrl+2 (取引履歴)<br>
-                                    <strong>サブタブ:</strong> Ctrl+S (サマリー) / Ctrl+← (前) / Ctrl+→ (次)
                                 </div>
                             </div>
 

--- a/portfolio.js
+++ b/portfolio.js
@@ -118,6 +118,13 @@ function refreshPortfolioDisplay(portfolioData = null, message = null) {
     // サマリー部分も更新（総合損益反映のため）
     updateDataStatus(currentData);
 
+    // 銘柄別サブタブを再生成（価格データを反映）
+    try {
+        createCoinNameSubtabs(currentData);
+    } catch (error) {
+        console.error('❌ Error in createCoinNameSubtabs:', error);
+    }
+
     // 成功メッセージ表示
     if (message) {
         showSuccessMessage(message);
@@ -676,10 +683,28 @@ function generatePortfolioTable(portfolioData) {
                     <div style="font-size: 10px; color: #6b7280; margin-top: 2px;">${stats.overallTotalProfitMargin >= 0 ? '+' : ''}${stats.overallTotalProfitMargin.toFixed(1)}%</div>
                 </div>
 
-                <!-- 損益状況 -->
+                <!-- 投資額 -->
                 <div style="text-align: center; padding: 12px; background: #f9fafb; border-radius: 6px; border: 1px solid #e5e7eb;">
-                    <div style="font-size: 11px; color: #6b7280; margin-bottom: 4px; font-weight: 500;">損益状況</div>
-                    <div style="font-size: 15px; font-weight: 600; color: #374151;">利益${stats.totalProfitableCoinNames || 0}・損失${stats.totalLossCoinNames || 0}</div>
+                    <div style="font-size: 11px; color: #6b7280; margin-bottom: 4px; font-weight: 500;">投資額</div>
+                    <div style="font-size: 15px; font-weight: 600; color: #374151;">¥${Math.abs(stats.totalInvestment).toLocaleString()}</div>
+                </div>
+
+                <!-- 実現損益 -->
+                <div style="text-align: center; padding: 12px; background: #f9fafb; border-radius: 6px; border: 1px solid #e5e7eb;">
+                    <div style="font-size: 11px; color: #6b7280; margin-bottom: 4px; font-weight: 500;">実現損益</div>
+                    <div style="font-size: 15px; font-weight: 600; color: ${stats.totalRealizedProfit >= 0 ? '#059669' : '#dc2626'};">${stats.totalRealizedProfit >= 0 ? '+' : ''}¥${Math.round(stats.totalRealizedProfit).toLocaleString()}</div>
+                </div>
+
+                <!-- 含み損益 -->
+                <div style="text-align: center; padding: 12px; background: #f9fafb; border-radius: 6px; border: 1px solid #e5e7eb;">
+                    <div style="font-size: 11px; color: #6b7280; margin-bottom: 4px; font-weight: 500;">含み損益</div>
+                    <div style="font-size: 15px; font-weight: 600; color: ${(stats.totalUnrealizedProfit || 0) >= 0 ? '#059669' : '#dc2626'};">${(stats.totalUnrealizedProfit || 0) >= 0 ? '+' : ''}¥${Math.round(stats.totalUnrealizedProfit || 0).toLocaleString()}</div>
+                </div>
+
+                <!-- 手数料 -->
+                <div style="text-align: center; padding: 12px; background: #f9fafb; border-radius: 6px; border: 1px solid #e5e7eb;">
+                    <div style="font-size: 11px; color: #6b7280; margin-bottom: 4px; font-weight: 500;">手数料</div>
+                    <div style="font-size: 15px; font-weight: 600; color: #374151;">¥${stats.totalFees.toLocaleString()}</div>
                 </div>
             </div>
 

--- a/services/ui-service.js
+++ b/services/ui-service.js
@@ -245,6 +245,7 @@ class TabManager {
                 tabButton.className = 'subtab-button coinName-subtab';
                 tabButton.id = `subtab-${coinNameData.coinName.toLowerCase()}`;
                 tabButton.textContent = coinNameData.coinName;
+                tabButton.title = 'Ctrl+← (前へ) | Ctrl+→ (次へ)';
                 tabButton.onclick = () => this.switchSubTab(coinNameData.coinName.toLowerCase());
 
                 // 損益に応じて色分け（data属性に保存して切り替え時に復元できるようにする）
@@ -340,19 +341,6 @@ class TableRenderer {
         const profitIcon = coinSummary.realizedProfit > 0 ? '📈' : coinSummary.realizedProfit < 0 ? '📉' : '➖';
 
         let html = `
-            <!-- 銘柄チャート -->
-            <div style="background: white; border: 1px solid #cbd5e1; border-radius: 12px; padding: 20px; margin-bottom: 25px; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);">
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
-                    <h3 style="margin: 0; font-size: 18px; font-weight: 600; color: #1e293b;">📈 ${coinSummary.coinName} 損益推移（過去1か月）</h3>
-                    <button onclick="renderCoinProfitChart('${coinSummary.coinName}')" style="padding: 8px 16px; background: #3b82f6; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 14px; font-weight: 500;">
-                        チャート更新
-                    </button>
-                </div>
-                <div style="height: 350px; position: relative;">
-                    <canvas id="${coinSummary.coinName.toLowerCase()}-profit-chart" style="max-height: 350px;"></canvas>
-                </div>
-            </div>
-
             <!-- 銘柄サマリーカード -->
             <div style="background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%); border: 1px solid #cbd5e1; border-radius: 12px; padding: 20px; margin-bottom: 25px; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);">
                 <div style="text-align: center; margin-bottom: 15px;">
@@ -460,6 +448,19 @@ class TableRenderer {
         html += `
                         </tbody>
                     </table>
+                </div>
+            </div>
+
+            <!-- 銘柄チャート -->
+            <div style="background: white; border: 1px solid #cbd5e1; border-radius: 12px; padding: 20px; margin-bottom: 25px; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
+                    <h3 style="margin: 0; font-size: 18px; font-weight: 600; color: #1e293b;">📈 ${coinSummary.coinName} 含み損益推移（過去1か月）</h3>
+                    <button onclick="renderCoinProfitChart('${coinSummary.coinName}')" style="padding: 8px 16px; background: #3b82f6; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 14px; font-weight: 500;">
+                        チャート更新
+                    </button>
+                </div>
+                <div style="height: 350px; position: relative;">
+                    <canvas id="${coinSummary.coinName.toLowerCase()}-profit-chart" style="max-height: 350px;"></canvas>
                 </div>
             </div>
         `;


### PR DESCRIPTION
主な変更点:
- キーボードショートカットを各タブのツールチップに表示
- ポートフォリオサマリーの「損益状況」セクションを削除
- 各銘柄タブでチャートを詳細分析の下に配置
- サマリーチャートを総合損益のみに変更
- 各銘柄チャートを含み損益のみに変更
- 価格更新時にサブタブを再生成し、最新価格を反映

変更ファイル:
- index.html: ツールチップ追加、キーボードショートカット説明削除
- portfolio.js: 損益状況セクション削除、refreshPortfolioDisplayでサブタブ再生成
- services/chart-service.js: チャートタイプに応じてデータセットを変更
- services/ui-service.js: 銘柄タブのレイアウト変更、ツールチップ追加